### PR TITLE
Added option for custom @NotNull messages

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,6 +49,12 @@ Generates:
 * @Digits if there is a totalDigits or fractionDigits restriction.
 * @Pattern if there is a Pattern restriction
 
+@NotNull's default validation message is not always helpful, so it can be customized with **-XJsr303Annotations:notNullAnnotationsCustomMessages=OPTION** where **OPTION** is one of the following:
+* `false` (default: no custom message -- not useful)
+* `true` (message is present but equivalent to the default: **"{javax.validation.constraints.NotNull.message}"** -- not useful)
+* `FieldName` (field name is prefixed to the default message: **"field {javax....message}"**)
+* `ClassName` (class and field name are prefixed to the default message: **"Class.field {javax....message}"**)
+* `other-non-empty-text` (arbitrary message, with substitutable, case-sensitive parameters `{ClassName}` and `{FieldName}`: **"Class {ClassName} field {FieldName} non-null"**)
 
 XReplacePrimitives
 ----------------
@@ -85,6 +91,8 @@ Usage:
                             <extraarg>-xjc-XJsr303Annotations:targetNamespace=http://www.foo.com/bar</extraarg>
                          	<!--optional, this is default values-->
                             <extraarg>-xjc-XJsr303Annotations:generateNotNullAnnotations=true</extraarg>
+                         	<!--optional, default is false, possible values are true, FieldName, ClassName, or an actual message -->
+                            <extraarg>-xjc-XJsr303Annotations:notNullAnnotationsCustomMessages=false</extraarg>
                             <extraarg>-xjc-XJsr303Annotations:JSR_349=false</extraarg>
                             <extraarg>-xjc-XJsr303Annotations:verbose=false</extraarg>
                         </extraargs>

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
@@ -51,15 +51,20 @@ public class JaxbValidationsPlugins extends Plugin {
 	public static final String TARGET_NAMESPACE_PARAMETER_NAME = PLUGIN_OPTION_NAME + ":targetNamespace";
 	public static final String JSR_349 = PLUGIN_OPTION_NAME + ":JSR_349";
 	public static final String GENERATE_NOT_NULL_ANNOTATIONS = PLUGIN_OPTION_NAME + ":generateNotNullAnnotations";
+  public static final String NOT_NULL_ANNOTATIONS_CUSTOM_MESSAGES = PLUGIN_OPTION_NAME + ":notNullAnnotationsCustomMessages";
 	public static final String VERBOSE = PLUGIN_OPTION_NAME + ":verbose";
-        public static final String GENERATE_JPA_ANNOTATIONS = PLUGIN_OPTION_NAME + ":jpa";
+  public static final String GENERATE_JPA_ANNOTATIONS = PLUGIN_OPTION_NAME + ":jpa";
 
 	protected String namespace = "http://jaxb.dev.java.net/plugin/code-injector";
 	public String targetNamespace = null;
 	public boolean jsr349 = false;
 	public boolean verbose = true;
 	public boolean notNullAnnotations = true;
-        public boolean jpaAnnotations = false;
+  public boolean notNullCustomMessages;
+  public boolean notNullPrefixFieldName;
+  public boolean notNullPrefixClassName;
+  public String notNullCustomMessage = null;
+  public boolean jpaAnnotations = false;
 
 	public String getOptionName() {
 		return PLUGIN_OPTION_NAME;
@@ -87,6 +92,22 @@ public class JaxbValidationsPlugins extends Plugin {
 					+ GENERATE_NOT_NULL_ANNOTATIONS.length() + "=".length()));
 			consumed++;
 		}
+
+    int index_notNullCustomMessages = arg1.indexOf(NOT_NULL_ANNOTATIONS_CUSTOM_MESSAGES);
+    if (index_notNullCustomMessages > 0) {
+      String value = arg1.substring(index_notNullCustomMessages + NOT_NULL_ANNOTATIONS_CUSTOM_MESSAGES.length() + "=".length()).trim();
+      notNullCustomMessages = Boolean.parseBoolean(value);
+      if (!notNullCustomMessages) {
+        if (value.equalsIgnoreCase("classname")) {
+          notNullCustomMessages = notNullPrefixFieldName = notNullPrefixClassName = true;
+        } else if (value.equalsIgnoreCase("fieldname")) {
+          notNullCustomMessages = notNullPrefixFieldName = true;
+        } else if (!value.equals("") && !value.equals("FALSE")) {
+          notNullCustomMessage = value;
+        }
+      }
+      consumed++;
+    }
 
 		int index_verbose = arg1.indexOf(VERBOSE);
 		if (index_verbose > 0) {
@@ -158,11 +179,7 @@ public class JaxbValidationsPlugins extends Plugin {
 		boolean required = property.isRequired();
 		if (minOccurs < 0 || minOccurs >= 1 && required) {
 			if (!hasAnnotation(field, NotNull.class)) {
-				if (notNullAnnotations) {
-					log("@NotNull: " + propertyName(property) + " added to class "
-							+ classOutline.implClass.name());
-					field.annotate(NotNull.class);
-				}
+        processNotNull(classOutline, field);
 			}
 		}
 		if (maxOccurs > 1) {
@@ -203,6 +220,22 @@ public class JaxbValidationsPlugins extends Plugin {
 			processType((XSSimpleType) elementType.getBaseType(), var, propertyName, className);
 		}
 	}
+
+  private void processNotNull(ClassOutline co, JFieldVar field) {
+    if (notNullAnnotations) {
+      log("@NotNull: " + field.name() + " added to class " + co.implClass.name());
+      JAnnotationUse annotation = field.annotate(NotNull.class);
+      if (notNullPrefixClassName) {
+        annotation.param("message", String.format("%s.%s {%s.message}", co.implClass.name(), field.name(), NotNull.class.getName()));
+      } else if (notNullPrefixFieldName) {
+        annotation.param("message", String.format("%s {%s.message}", field.name(), NotNull.class.getName()));
+      } else if (notNullCustomMessages) {
+        annotation.param("message", String.format("{%s.message}", NotNull.class.getName()));
+      } else if (notNullCustomMessage != null) {
+        annotation.param("message", notNullCustomMessage.replace("{ClassName}", co.implClass.name()).replace("{FieldName}", field.name()));
+      }
+    }
+  }
 
 	private void validAnnotation(final XSType elementType, JFieldVar var, final String propertyName,
 								 final String className) {
@@ -379,10 +412,7 @@ public class JaxbValidationsPlugins extends Plugin {
 		JFieldVar var = clase.implClass.fields().get(propertyName);
 		if (particle.isRequired()) {
 			if (!hasAnnotation(var, NotNull.class)) {
-				if (notNullAnnotations) {
-					log("@NotNull: " + propertyName + " added to class " + className);
-					var.annotate(NotNull.class);
-				}
+        processNotNull(clase, var);
 			}
 		}
 


### PR DESCRIPTION
I created the option for a custom `message` argument to the generated `@NotNull` annotations. In some cases I can't track down the failing class/field combination, but this patch solves my problem.
