### PR TITLE
Added support for String enumerations

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
@@ -366,29 +366,25 @@ public class JaxbValidationsPlugins extends Plugin {
 					}
 				}
 			}
-		} else {
+		} else if ("String".equals(field.type().name())) {
 			final List<XSFacet> enumerationList = simpleType.getFacets("enumeration");
 			if (enumerationList.size() > 1) { // More than one pattern
 				log("@Pattern.List: " + propertyName + " added to class " + className);
 				final JAnnotationUse patternListAnnotation = field.annotate(Pattern.List.class);
 				final JAnnotationArrayMember listValue = patternListAnnotation.paramArray("value");
-				if ("String".equals(field.type().name())) {
-					for (XSFacet xsFacet : enumerationList) {
-						final String value = xsFacet.getValue().value;
-						// cxf-codegen fix
-						if (!"\\c+".equals(value)) {
-							listValue.annotate(Pattern.class).param("regexp", replaceXmlProprietals(value));
-						}
+				for (XSFacet xsFacet : enumerationList) {
+					final String value = xsFacet.getValue().value;
+					// cxf-codegen fix
+					if (!"\\c+".equals(value)) {
+						listValue.annotate(Pattern.class).param("regexp", replaceXmlProprietals(value));
 					}
 				}
 			} else if (simpleType.getFacet("enumeration") != null) {
 				final String pattern = simpleType.getFacet("enumeration").getValue().value;
-				if ("String".equals(field.type().name())) {
-					// cxf-codegen fix
-					if (!"\\c+".equals(pattern)) {
-						log("@Pattern(" + pattern + "): " + propertyName + " added to class " + className);
-						field.annotate(Pattern.class).param("regexp", replaceXmlProprietals(pattern));
-					}
+				// cxf-codegen fix
+				if (!"\\c+".equals(pattern)) {
+					log("@Pattern(" + pattern + "): " + propertyName + " added to class " + className);
+					field.annotate(Pattern.class).param("regexp", replaceXmlProprietals(pattern));
 				}
 			}
 		}


### PR DESCRIPTION
**The issue**
Currently enumerations cannot be validated using the validation api.
In addition to that the default generator doesn't leave a hint that only specified values can be used for this entry maing it almost impossible for a annotation aware generator to generate a valid request.

**The Fix**
If no Regex pattern is specified the generator will add a regex pattern for all enumerations.
Due to this change all String enumeration values can be easyly checked by looking at the annotation.
