### PR TITLE
Simplyfied logic, once a string always a string.

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
@@ -304,8 +304,8 @@ public class JaxbValidationsPlugins extends Plugin {
 			JAnnotationUse patternListAnnotation = field.annotate(Pattern.List.class);
 			JAnnotationArrayMember listValue = patternListAnnotation.paramArray("value");
 
-			for (XSFacet xsFacet : patternList) {
-				if ("String".equals(field.type().name())) {
+			if ("String".equals(field.type().name())) {
+				for (XSFacet xsFacet : patternList) {
 					final String value = xsFacet.getValue().value;
 					// cxf-codegen fix
 					if (!"\\c+".equals(value)) {


### PR DESCRIPTION
**The issue**
No real issue, but if the field is a string once, it will always be a String so checking every time in the loop has no use.

**The Fix**
Moves the "is String" check in front of the loop, to avoid multiple checks with the same result.
