### PR TITLE
Adding support for case minoccurs=1, maxoccurs=1, nillable=true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>com.github.krasa</groupId>
 	<artifactId>krasa-jaxb-tools</artifactId>
-	<version>1.3</version>
+	<version>1.4-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>krasa-jaxb-tools</name>

--- a/src/test/java/tests/NillableTest.java
+++ b/src/test/java/tests/NillableTest.java
@@ -1,0 +1,41 @@
+package tests;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.project.MavenProject;
+import org.jvnet.jaxb2.maven2.AbstractXJC2Mojo;
+import org.jvnet.jaxb2.maven2.test.RunXJC2Mojo;
+
+public class NillableTest extends RunXJC2Mojo {
+
+	public static final String STRING = "nillable";
+
+	protected File getGeneratedDirectory() {
+		return new File(getBaseDir(), "target/generated-sources/" + STRING);
+	}
+
+	@Override
+	public File getSchemaDirectory() {
+		return new File(getBaseDir(), "src/test/resources/" + STRING);
+	}
+
+	@Override
+	protected void configureMojo(AbstractXJC2Mojo mojo) {
+		super.configureMojo(mojo);
+		mojo.setProject(new MavenProject());
+		mojo.setForceRegenerate(true);
+		mojo.setExtension(true);
+
+	}
+
+	@Override
+	public List<String> getArgs() {
+		final List<String> args = new ArrayList<String>(super.getArgs());
+		args.add("-XJsr303Annotations");
+		args.add("-XJsr303Annotations:generateNotNullAnnotations=true");
+		// args.add("-XJsr303Annotations:JSR_349=true");
+		return args;
+	}
+}

--- a/src/test/resources/nillable/nillable.xsd
+++ b/src/test/resources/nillable/nillable.xsd
@@ -1,0 +1,15 @@
+<xsd:schema
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		targetNamespace="a"
+		xmlns:a="a"
+		elementFormDefault="qualified">
+
+	<xsd:element name="main" type="a:Main"/>
+
+	<xsd:complexType name="Main">
+		<xsd:sequence>
+			<xsd:element minOccurs="1" maxOccurs="1" nillable="true" name="notNullString" type="xsd:string"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
As the title suggests, it would be nice if we could handle the case when someone specifies that an element is always sent, but could be sent as null. 