### PR TITLE
Best possible fix for #40 due to impedance mismatch JSR303 vs XSD

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
@@ -344,7 +344,7 @@ public class JaxbValidationsPlugins extends Plugin {
 			if (!hasAnnotation(field, Digits.class)) {
 				log("@Digits(" + totalDigits + "," + fractionDigits + "): " + propertyName
 						+ " added to class " + className);
-				JAnnotationUse annox = field.annotate(Digits.class).param("integer", (totalDigits - fractionDigits));
+				JAnnotationUse annox = field.annotate(Digits.class).param("integer", totalDigits);
 				annox.param("fraction", fractionDigits);
 			}
 			if (jpaAnnotations) {


### PR DESCRIPTION
xsd does not align totally with JSR303 - so the best we can do is to actually allow for all digits to be integers which is a valid edge-case.