### PR TITLE
Exclude "serialVersionUID" from processing XReplacePrimitives

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/krasa/PrimitiveFixerPlugin.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/PrimitiveFixerPlugin.java
@@ -43,6 +43,15 @@ public class PrimitiveFixerPlugin extends Plugin {
             for (Map.Entry<String, JFieldVar> stringJFieldVarEntry : fields.entrySet()) {
                 JFieldVar fieldVar = stringJFieldVarEntry.getValue();
                 JType type = fieldVar.type();
+                
+                /*
+                 * Exclude "serialVersionUID" from processing XReplacePrimitives as this will 
+                 * have no getter or setter defined.
+                 */
+                if ("serialVersionUID".equals(fieldVar.name())) {
+                	continue;
+                }
+                    
                 if (type.isPrimitive()) {
                     Class o = hashMap.get(type.name());
                     if (o != null) {


### PR DESCRIPTION
Using an xjc binding

```
<jxb:globalBindings>
   <jxb:serializable uid="1"/>  
</jxb:globalBindings>
```

(i.e. **with** a uid attribute defined) generates the code

`private final static long serialVersionUID = 1L;`

`-XReplacePrimitives` then tries to replace that field and the (non existent) getter and setter and this results in an RTE.
