### PR TITLE
Generate bean validation annotations on service interface

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,7 +22,7 @@ Snapshot:
 <dependency>
     <groupId>com.github.krasa</groupId>
     <artifactId>krasa-jaxb-tools</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.6-SNAPSHOT</version>
 </dependency>
 
 <repository>
@@ -62,6 +62,15 @@ Generates:
 * `ClassName` (class and field name are prefixed to the default message: **"Class.field {javax....message}"**)
 * `other-non-empty-text` (arbitrary message, with substitutable, case-sensitive parameters `{ClassName}` and `{FieldName}`: **"Class {ClassName} field {FieldName} non-null"**)
 
+----------------
+
+Bean validation policy can be customized with **-XJsr303Annotations:generateValidationAnnotations=OPTION** where **OPTION** is one of the following:
+* `InOut` (default: validate requests and responses)
+* `In` (validate only requests)
+* `Out` (validate only responses)
+
+**Using this option requires to specify krasa as front end generator** (See example below)
+
 ---- 
 XReplacePrimitives
 ----------------
@@ -100,6 +109,10 @@ Usage:
                             <extraarg>-xjc-XJsr303Annotations:notNullAnnotationsCustomMessages=false</extraarg>
                             <extraarg>-xjc-XJsr303Annotations:JSR_349=false</extraarg>
                             <extraarg>-xjc-XJsr303Annotations:verbose=false</extraarg>
+                            <!--optional Only needed for generateValidationAnnotations, which possible values are InOut (default), In, Out -->
+                            <extraarg>-fe</extraarg>
+                            <extraarg>krasa</extraarg>
+                            <extraarg>-xjc-XJsr303Annotations:generateValidationAnnotations=In</extraarg>
                         </extraargs>
                     </wsdlOption>
                 </wsdlOptions>

--- a/README.markdown
+++ b/README.markdown
@@ -64,7 +64,7 @@ Generates:
 
 ----------------
 
-Bean validation policy can be customized with **-XJsr303Annotations:generateValidationAnnotations=OPTION** where **OPTION** is one of the following:
+Bean validation policy can be customized with **-XJsr303Annotations:generateServiceValidationAnnotations=OPTION** where **OPTION** is one of the following:
 * `InOut` (default: validate requests and responses)
 * `In` (validate only requests)
 * `Out` (validate only responses)
@@ -109,10 +109,10 @@ Usage:
                             <extraarg>-xjc-XJsr303Annotations:notNullAnnotationsCustomMessages=false</extraarg>
                             <extraarg>-xjc-XJsr303Annotations:JSR_349=false</extraarg>
                             <extraarg>-xjc-XJsr303Annotations:verbose=false</extraarg>
-                            <!--optional Only needed for generateValidationAnnotations, which possible values are InOut (default), In, Out -->
+                            <!--optional, only needed for generateServiceValidationAnnotations, which possible values are InOut (default), In, Out -->
                             <extraarg>-fe</extraarg>
                             <extraarg>krasa</extraarg>
-                            <extraarg>-xjc-XJsr303Annotations:generateValidationAnnotations=In</extraarg>
+                            <extraarg>-xjc-XJsr303Annotations:generateServiceValidationAnnotations=In</extraarg>
                         </extraargs>
                     </wsdlOption>
                 </wsdlOptions>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 		<maven-compiler-plugin.version>2.5.1</maven-compiler-plugin.version>
 		<maven-surefire-plugin.version>2.14.1</maven-surefire-plugin.version>
 		<javax-persistence.version>2.1.0</javax-persistence.version>
+        <cxf.version>2.2.3</cxf.version>
 	</properties>
 
 	<build>
@@ -111,6 +112,11 @@
 			<artifactId>validation-api</artifactId>
 			<version>${validation-api.version}</version>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-codegen-plugin</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
 
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-codegen-plugin</artifactId>
             <version>${cxf.version}</version>
+            <scope>provided</scope>
         </dependency>
 
 

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
@@ -55,7 +55,7 @@ public class JaxbValidationsPlugins extends Plugin {
 	public static final String NOT_NULL_ANNOTATIONS_CUSTOM_MESSAGES = PLUGIN_OPTION_NAME + ":notNullAnnotationsCustomMessages";
 	public static final String VERBOSE = PLUGIN_OPTION_NAME + ":verbose";
 	public static final String GENERATE_JPA_ANNOTATIONS = PLUGIN_OPTION_NAME + ":jpa";
-	public static final String GENERATE_VALIDATION_ANNOTATIONS = PLUGIN_OPTION_NAME + ":generateValidationAnnotations";
+	public static final String GENERATE_SERVICE_VALIDATION_ANNOTATIONS = PLUGIN_OPTION_NAME + ":generateServiceValidationAnnotations";
 
 	protected String namespace = "http://jaxb.dev.java.net/plugin/code-injector";
 	public String targetNamespace = null;
@@ -67,7 +67,7 @@ public class JaxbValidationsPlugins extends Plugin {
 	public boolean notNullPrefixClassName;
 	public String notNullCustomMessage = null;
 	public boolean jpaAnnotations = false;
-	public String validationAnnotations = null;
+	public String serviceValidationAnnotations = null;
 
 	public String getOptionName() {
 		return PLUGIN_OPTION_NAME;
@@ -125,10 +125,10 @@ public class JaxbValidationsPlugins extends Plugin {
 			consumed++;
 		}
 
-		int index_validationAnnotation = arg1.indexOf(GENERATE_VALIDATION_ANNOTATIONS);
-		if (index_validationAnnotation > 0) {
-			validationAnnotations = arg1.substring(index_validationAnnotation
-					+ GENERATE_VALIDATION_ANNOTATIONS.length() + "=".length()).trim();
+		int index_serviceValidationAnnotation = arg1.indexOf(GENERATE_SERVICE_VALIDATION_ANNOTATIONS);
+		if (index_serviceValidationAnnotation > 0) {
+			serviceValidationAnnotations = arg1.substring(index_serviceValidationAnnotation
+					+ GENERATE_SERVICE_VALIDATION_ANNOTATIONS.length() + "=".length()).trim();
 			consumed++;
 		}
 

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
@@ -55,6 +55,7 @@ public class JaxbValidationsPlugins extends Plugin {
 	public static final String NOT_NULL_ANNOTATIONS_CUSTOM_MESSAGES = PLUGIN_OPTION_NAME + ":notNullAnnotationsCustomMessages";
 	public static final String VERBOSE = PLUGIN_OPTION_NAME + ":verbose";
 	public static final String GENERATE_JPA_ANNOTATIONS = PLUGIN_OPTION_NAME + ":jpa";
+	public static final String GENERATE_VALIDATION_ANNOTATIONS = PLUGIN_OPTION_NAME + ":generateValidationAnnotations";
 
 	protected String namespace = "http://jaxb.dev.java.net/plugin/code-injector";
 	public String targetNamespace = null;
@@ -66,6 +67,7 @@ public class JaxbValidationsPlugins extends Plugin {
 	public boolean notNullPrefixClassName;
 	public String notNullCustomMessage = null;
 	public boolean jpaAnnotations = false;
+	public String validationAnnotations = null;
 
 	public String getOptionName() {
 		return PLUGIN_OPTION_NAME;
@@ -120,6 +122,13 @@ public class JaxbValidationsPlugins extends Plugin {
 		if (index_generateJpaAnnotations > 0) {
 			jpaAnnotations = Boolean.parseBoolean(arg1.substring(index_generateJpaAnnotations
 					+ GENERATE_JPA_ANNOTATIONS.length() + "=".length()));
+			consumed++;
+		}
+
+		int index_validationAnnotation = arg1.indexOf(GENERATE_VALIDATION_ANNOTATIONS);
+		if (index_validationAnnotation > 0) {
+			validationAnnotations = arg1.substring(index_validationAnnotation
+					+ GENERATE_VALIDATION_ANNOTATIONS.length() + "=".length()).trim();
 			consumed++;
 		}
 

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/ValidSEIGenerator.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/ValidSEIGenerator.java
@@ -67,7 +67,7 @@ public class ValidSEIGenerator extends SEIGenerator {
 			String[] xjcArgs = (String[]) penv.get(ToolConstants.CFG_XJC_ARGS);
 			for (String arg : xjcArgs) {
 				String[] parts = arg.split("=");
-				if (parts[0].contains(JaxbValidationsPlugins.GENERATE_VALIDATION_ANNOTATIONS)) {
+				if (parts[0].contains(JaxbValidationsPlugins.GENERATE_SERVICE_VALIDATION_ANNOTATIONS)) {
 					parseValidationPolicy(parts[1]);
 				}
 				LOG.log(Level.FINE, "xjc arg:" + arg);

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/ValidSEIGenerator.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/ValidSEIGenerator.java
@@ -1,0 +1,89 @@
+package com.sun.tools.xjc.addon.krasa;
+
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+import javax.validation.Valid;
+import javax.xml.namespace.QName;
+
+import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.tools.common.ToolConstants;
+import org.apache.cxf.tools.common.ToolContext;
+import org.apache.cxf.tools.common.ToolException;
+import org.apache.cxf.tools.common.model.JAnnotation;
+import org.apache.cxf.tools.common.model.JavaInterface;
+import org.apache.cxf.tools.common.model.JavaMethod;
+import org.apache.cxf.tools.common.model.JavaModel;
+import org.apache.cxf.tools.common.model.JavaParameter;
+import org.apache.cxf.tools.wsdlto.frontend.jaxws.generators.SEIGenerator;
+import org.apache.cxf.tools.wsdlto.frontend.jaxws.processor.WSDLToJavaProcessor;
+
+public class ValidSEIGenerator extends SEIGenerator {
+
+	private static final String VALID_PARAM = "VALID_PARAM";
+
+	private static final String VALID_RETURN = "VALID_RETURN";
+
+	private boolean validIn = true;
+
+	private boolean validOut = true;
+
+	@Override
+	public void generate(ToolContext penv) throws ToolException {
+		parseArguments(penv);
+
+		JAnnotation validAnno = new JAnnotation(Valid.class);
+		Map<QName, JavaModel> map = CastUtils.cast((Map<?, ?>) penv.get(WSDLToJavaProcessor.MODEL_MAP));
+		for (JavaModel javaModel : map.values()) {
+			Map<String, JavaInterface> interfaces = javaModel.getInterfaces();
+
+			for (JavaInterface intf : interfaces.values()) {
+				intf.addImport(Valid.class.getCanonicalName());
+				List<JavaMethod> methods = intf.getMethods();
+
+				for (JavaMethod method : methods) {
+					List<JavaParameter> parameters = method.getParameters();
+					if (validOut) {
+						method.addAnnotation(VALID_RETURN, validAnno);
+					}
+					for (JavaParameter param : parameters) {
+						if (validIn && (param.isIN() || param.isINOUT())) {
+							param.addAnnotation(VALID_PARAM, validAnno);
+						}
+						if (validOut && (param.isOUT() || param.isINOUT())) {
+							param.addAnnotation(VALID_RETURN, validAnno);
+						}
+					}
+				}
+			}
+		}
+
+		super.generate(penv);
+	}
+
+	private void parseArguments(ToolContext penv) {
+		if (penv.get(ToolConstants.CFG_XJC_ARGS) != null) {
+			String[] xjcArgs = (String[]) penv.get(ToolConstants.CFG_XJC_ARGS);
+			for (String arg : xjcArgs) {
+				String[] parts = arg.split("=");
+				if (parts[0].contains(JaxbValidationsPlugins.GENERATE_VALIDATION_ANNOTATIONS)) {
+					parseValidationPolicy(parts[1]);
+				}
+				LOG.log(Level.FINE, "xjc arg:" + arg);
+			}
+		}
+	}
+
+	public void parseValidationPolicy(String policy) {
+		if ("in".equalsIgnoreCase(policy)) {
+			validOut = false;
+		} else if ("out".equalsIgnoreCase(policy)) {
+			validIn = false;
+		}
+	}
+
+	public String getName() {
+		return "krasa";
+	}
+}

--- a/src/main/resources/META-INF/tools-plugin.xml
+++ b/src/main/resources/META-INF/tools-plugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plugin xmlns="http://cxf.apache.org/tools/plugin" name="krasa-jaxb-tool" version="" provider="krasa.addon.xjc.tools.sun.com">
+    <frontend name="krasa" package="org.apache.cxf.tools.wsdlto.frontend.jaxws" profile="JAXWSProfile">
+        <container name="JAXWSContainer" package="org.apache.cxf.tools.wsdlto.frontend.jaxws" toolspec="jaxws-toolspec.xml" />
+        <processor name="WSDLToJavaProcessor" package="org.apache.cxf.tools.wsdlto.frontend.jaxws.processor" />
+        <builder name="JAXWSDefinitionBuilder" package="org.apache.cxf.tools.wsdlto.frontend.jaxws.wsdl11" />
+        <generators package="com.sun.tools.xjc.addon.krasa">
+            <generator name="ValidSEIGenerator" />
+        </generators>
+    </frontend>
+</plugin>


### PR DESCRIPTION
This plugin is missing an important feature. While it generates JSR-303 annotations on the model, it does not add @Valid annotation on the service interface. This is really a gap since bean validation (as implemented in [cxf validation feature](https://cwiki.apache.org/confluence/display/CXF20DOC/ValidationFeature)) requires the service interface to be annotated in order to be triggered.
So, up to now the only way to run the validation is an hard coded call to a bean validator in the service implementation.

This PR fills the gap, as thoroughly described in this [stackoverflow discussion](http://stackoverflow.com/questions/41852213/cxf-codegen-plugin-does-not-comply-with-cxf-validationfeature)