### PR TITLE
Implementation for multiple Patterns with own base-restriction-simple…

### DIFF
--- a/src/test/java/tests/MultiplePatternsWithBasePluginTest.java
+++ b/src/test/java/tests/MultiplePatternsWithBasePluginTest.java
@@ -1,0 +1,39 @@
+package tests;
+
+import org.apache.maven.project.MavenProject;
+import org.jvnet.jaxb2.maven2.AbstractXJC2Mojo;
+import org.jvnet.jaxb2.maven2.test.RunXJC2Mojo;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MultiplePatternsWithBasePluginTest extends RunXJC2Mojo {
+
+    public static final String STRING = "multiplePatternsWithBase";
+
+    protected File getGeneratedDirectory() {
+        return new File(getBaseDir(), "target/generated-sources/" + STRING);
+    }
+
+    @Override
+    public File getSchemaDirectory() {
+        return new File(getBaseDir(), "src/test/resources/" + STRING);
+    }
+
+    @Override
+    protected void configureMojo(AbstractXJC2Mojo mojo) {
+        super.configureMojo(mojo);
+        mojo.setProject(new MavenProject());
+        mojo.setForceRegenerate(true);
+        mojo.setExtension(true);
+    }
+
+    @Override
+    public List<String> getArgs() {
+        final List<String> args = new ArrayList<String>(super.getArgs());
+        args.add("-XJsr303Annotations");
+        return args;
+    }
+
+}

--- a/src/test/resources/multiplePatternsWithBase/multiplePatternsWithBase.xsd
+++ b/src/test/resources/multiplePatternsWithBase/multiplePatternsWithBase.xsd
@@ -1,0 +1,29 @@
+<xsd:schema
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		targetNamespace="a"
+		xmlns:a="a"
+		elementFormDefault="qualified">
+
+	<xsd:element name="main" type="a:Main"/>
+
+	<xsd:complexType name="Main">
+		<xsd:sequence>
+			<xsd:element maxOccurs="1" minOccurs="0" name="multiplePatternsWithBase" type="a:patternList"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:simpleType name="patternList">
+		<xsd:restriction base="a:patternListBase">
+			<xsd:pattern value="[0-9]" />
+			<xsd:pattern value="[A-B]" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:simpleType name="patternListBase">
+		<xsd:restriction base="xsd:string">
+			<xsd:pattern value="[Y-Z]" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+
+</xsd:schema>


### PR DESCRIPTION
The additional pattern in a simpletype-base restriction was ignored in the wsdl2java generation. 
Example:
```xml
<xsd:simpleType name="patternList">
		<xsd:restriction base="a:patternListBase">
			<xsd:pattern value="[0-9]" />
			<xsd:pattern value="[A-B]" />
		</xsd:restriction>
	</xsd:simpleType>

	<xsd:simpleType name="patternListBase">
		<xsd:restriction base="xsd:string">
			<xsd:pattern value="[Y-Z]" />
		</xsd:restriction>
	</xsd:simpleType>
```
The annotation in the java-class should look like this:
```java
@Pattern.List({
        @Pattern(regexp = "[Y-Z]"),
        @Pattern(regexp = "([0-9])|([A-B])")
    })
```
but before my changes it looked like this:
```java
@Pattern(regexp = "([0-9])|([A-B])")
```
Fix for issue #61