### PR TITLE
Skip classes that are incompatible with current Krasa implementation

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
@@ -167,6 +167,11 @@ public class JaxbValidationsPlugins extends Plugin {
 	 */
 	public void processElement(CElementPropertyInfo property, ClassOutline classOutline, Outline model) {
 		XSComponent schemaComponent = property.getSchemaComponent();
+		if (!(schemaComponent instanceof ParticleImpl)) {
+			log(String.format("Skipping class %s as it seem to have an incompatible property schema: %s",
+					classOutline.implClass.name(), schemaComponent.getClass().getName()));
+			return;
+		}
 		ParticleImpl particle = (ParticleImpl) schemaComponent;
 		// must be reflection because of cxf-codegen
 		int maxOccurs = toInt(Utils.getField("maxOccurs", particle));


### PR DESCRIPTION
Running krasa together with jaxb2-basics' `-Xsimplify` extension breaks the krasa as it's unable to correctly parse the schema. This is a hot-fix that simply skips the classes that are unable to be parsed.

This was verified to work with `-Xsimplify` extension, it successfully skips the classes that have been "simplified", which is not perfect but much better than crashing alltogether.