### PR TITLE
Add null checks in a couple of places to avoid stack traces when using <jaxb:globalBindings fixedAttributeAsConstantProperty="true" />.

### DIFF
--- a/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/JaxbValidationsPlugins.java
@@ -404,7 +404,7 @@ public class JaxbValidationsPlugins extends Plugin {
 					}
 				}
 			}
-		} else if ("String".equals(field.type().name())) {
+		} else if (field != null && "String".equals(field.type().name())) {
 			final List<XSFacet> enumerationList = simpleType.getFacets("enumeration");
 			if (enumerationList.size() > 1) { // More than one pattern
 				log("@Pattern: " + propertyName + " added to class " + className);
@@ -458,6 +458,9 @@ public class JaxbValidationsPlugins extends Plugin {
 	}
 
 	private boolean isSizeAnnotationApplicable(JFieldVar field) {
+		if(field == null) {
+			return false;
+		}
 		return field.type().name().equals("String")|| field.type().isArray() ;
 	}
 

--- a/src/main/java/com/sun/tools/xjc/addon/krasa/Utils.java
+++ b/src/main/java/com/sun/tools/xjc/addon/krasa/Utils.java
@@ -59,7 +59,11 @@ public class Utils {
 				return simpleField.get(oo);
 			}
 		} catch (Exception e) {
-			System.err.println("krasa-jaxb-tools - Field " + path + " not found on " + oo.getClass().getName() );
+			String className = null;
+			if(oo != null && oo.getClass() != null) {
+				className = oo.getClass().getName();
+			}
+			System.err.println("krasa-jaxb-tools - Field " + path + " not found on " + className );
 		}
 		return null;
 	}
@@ -115,6 +119,9 @@ public class Utils {
 	}
 
 	static boolean isCustomType(JFieldVar var) {
-        return "JDirectClass".equals(var.type().getClass().getSimpleName());
-    }
+		if(var == null) {
+			return false;
+		}
+		return "JDirectClass".equals(var.type().getClass().getSimpleName());
+	}
 }


### PR DESCRIPTION
Fixes #37